### PR TITLE
keep previous session

### DIFF
--- a/packages/walletconnect-solana/package.json
+++ b/packages/walletconnect-solana/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jnwng/walletconnect-solana",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "license": "Apache-2.0",
     "type": "module",
     "sideEffects": false,
@@ -28,13 +28,13 @@
         "@solana/web3.js": "1.50.1",
         "@types/node-fetch": "^2.6.2",
         "@types/pino": "6.3.11",
-        "@walletconnect/types": "2.0.0-rc.1",
+        "@walletconnect/types": "2.0.0-rc.2",
         "shx": "^0.3.4"
     },
     "dependencies": {
         "@walletconnect/qrcode-modal": "1.8.0",
-        "@walletconnect/sign-client": "2.0.0-rc.1",
-        "@walletconnect/utils": "2.0.0-rc.1",
+        "@walletconnect/sign-client": "2.0.0-rc.2",
+        "@walletconnect/utils": "2.0.0-rc.2",
         "better-sqlite3": "7.6.2",
         "bs58": "^5.0.0",
         "tslib": "^2.4.0"

--- a/packages/walletconnect-solana/package.json
+++ b/packages/walletconnect-solana/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jnwng/walletconnect-solana",
-    "version": "0.0.3",
+    "version": "0.0.2",
     "license": "Apache-2.0",
     "type": "module",
     "sideEffects": false,


### PR DESCRIPTION
- updated deps to WC rc2
- fixed session persistence
- using client.off (which is called during adapter disconnect()) throws an error saying the off function doesn't exist internally, so I replaced it with a patch that calls removeListener instead which works. Not sure exactly why this happens. You could avoid this by changing the solana walletconnect wallet adapter to call removeListener. Without this disconnect doesn't work and session is kept persisted until browser site data is cleared.
