### PR TITLE
Throw QRCodeModal error asynchronously

### DIFF
--- a/packages/walletconnect-solana/src/adapter.ts
+++ b/packages/walletconnect-solana/src/adapter.ts
@@ -71,15 +71,19 @@ export class WalletConnectWallet {
                     });
                 }
 
-                approval().then((session) => {
-                    this._session = session;
-                    // We assign this variable only after we're sure we've received approval
-                    this._client = client;
+                approval()
+                    .then((session) => {
+                        this._session = session;
+                        // We assign this variable only after we're sure we've received approval
+                        this._client = client;
 
-                    QRCodeModal.close();
+                        QRCodeModal.close();
 
-                    resolve({ publicKey: this.publicKey });
-                });
+                        resolve({ publicKey: this.publicKey });
+                    })
+                    .catch((error) => {
+                        reject(error);
+                    });
             });
         }
     }

--- a/packages/walletconnect-solana/src/adapter.ts
+++ b/packages/walletconnect-solana/src/adapter.ts
@@ -79,9 +79,7 @@ export class WalletConnectWallet {
 
                         resolve({ publicKey: this.publicKey });
                     })
-                    .catch((error) => {
-                        reject(error);
-                    })
+                    .catch(reject)
                     .finally(() => {
                         QRCodeModal.close();
                     });

--- a/packages/walletconnect-solana/src/adapter.ts
+++ b/packages/walletconnect-solana/src/adapter.ts
@@ -77,12 +77,13 @@ export class WalletConnectWallet {
                         // We assign this variable only after we're sure we've received approval
                         this._client = client;
 
-                        QRCodeModal.close();
-
                         resolve({ publicKey: this.publicKey });
                     })
                     .catch((error) => {
                         reject(error);
+                    })
+                    .finally(() => {
+                        QRCodeModal.close();
                     });
             });
         }


### PR DESCRIPTION
# Description

Closing the WalletConnect Modal causes the wallet connect button to be stuck in the "Connecting..." state. To reproduce the issue, go to http://poised-lumber.surge.sh/, click on any of the "Connect" buttons, and close the WalletConnect modal without connecting any wallet.

# How Has This Been Tested?

- [x] Connecting and disconnecting a wallet via https://react-wallet.walletconnect.com/
- [x] Rejecting a connection attempt
- [x] Closing the WalletConnect dialog without connecting to any wallet