### PR TITLE
Include .js extension for relative imports

### DIFF
--- a/packages/walletconnect-solana/src/adapter.ts
+++ b/packages/walletconnect-solana/src/adapter.ts
@@ -2,7 +2,7 @@ import WalletConnectClient from '@walletconnect/sign-client';
 import QRCodeModal from '@walletconnect/qrcode-modal';
 import { PublicKey } from '@solana/web3.js';
 
-import { ClientNotInitializedError, QRCodeModalError } from './errors';
+import { ClientNotInitializedError, QRCodeModalError } from './errors.js';
 
 import type { EngineTypes, SessionTypes, SignClientTypes } from '@walletconnect/types';
 import type { Transaction } from '@solana/web3.js';

--- a/packages/walletconnect-solana/src/index.ts
+++ b/packages/walletconnect-solana/src/index.ts
@@ -1,3 +1,3 @@
-export * from './adapter';
-export * from './errors';
+export * from './adapter.js';
+export * from './errors.js';
 export { default as WalletConnectClient } from '@walletconnect/sign-client';


### PR DESCRIPTION
The TypeScript compiler [does not add .js extensions automatically](https://github.com/microsoft/TypeScript/issues/42151) for ESM modules. However, relative imports for ES modules require an extension to work. Webpack lets you override this but the [default configuration throws an error](https://webpack.js.org/guides/ecma-script-modules/):

> Imports in ESM are resolved more strictly. Relative requests must include a filename and file extension (e.g. *.js or *.mjs) unless you have the behaviour disabled with [fullySpecified=false](https://webpack.js.org/configuration/module/#resolvefullyspecified).

This PR adds the `.js` extension to any relative imports in the package so that the esm build works correctly with Webpack 5+ (and similar build systems) out of the box. The only other way to fix this would be to introduce another build tool. This still works perfectly fine for the other module formats.