### PR TITLE
Fix Solana Mainnet RPC url 

### DIFF
--- a/packages/walletconnect-solana/src/adapter.ts
+++ b/packages/walletconnect-solana/src/adapter.ts
@@ -12,7 +12,7 @@ export interface WalletConnectWalletAdapterConfig {
 }
 
 export enum WalletConnectChainID {
-    Mainnet = 'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ',
+    Mainnet = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
     Devnet = 'solana:8E9rvCKLFQia2Y35HXjjpWzj8weVo44K',
 }
 


### PR DESCRIPTION
fix: updated solana wallet Mainnet connection based on
https://github.com/WalletConnect/blockchain-api/blob/master/SUPPORTED_CHAINS.md

There is no mention on the repo of a devnet URL. Only mainnet is supplied.