### PR TITLE
chore: bump walletconnect package versions

### DIFF
--- a/.changeset/bump-walletconnect-packages.md
+++ b/.changeset/bump-walletconnect-packages.md
@@ -1,0 +1,5 @@
+---
+"@walletconnect/solana-adapter": patch
+---
+
+Bump @walletconnect/universal-provider and @walletconnect/utils package versions


### PR DESCRIPTION
## Summary
- Adds changeset for bumping `@walletconnect/universal-provider` and `@walletconnect/utils` package versions

## Test plan
- [ ] Verify changeset is picked up by `changeset version`
- [ ] Confirm no breaking changes from the version bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)